### PR TITLE
chore: check licenses

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,28 @@
+name: Go License Check
+
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+  push:
+    branches: [main]
+
+jobs:
+  check-licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Check licenses
+        run: |
+          go-licenses check ./... --ignore github.com/tailor-inc --include_tests --disallowed_types=permissive,forbidden,restricted


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically check Go module licenses whenever dependencies change or code is pushed to the main branch. This helps ensure that only approved license types are used in the project.

Automation and compliance:

Added a .github/workflows/license.yml workflow that runs on changes to go.mod and go.sum, as well as pushes to main, to check for disallowed license types in Go dependencies using go-licenses.